### PR TITLE
Exception handle for empty tables

### DIFF
--- a/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/client/ElasticsearchClient.java
+++ b/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/client/ElasticsearchClient.java
@@ -492,6 +492,10 @@ public class ElasticsearchClient
                     // Older versions of ElasticSearch supported multiple "type" mappings
                     // for a given index. Newer versions support only one and don't
                     // expose it in the document. Here we skip it if it's present.
+
+                    if (!mappings.elements().hasNext()) {
+                        return new IndexMetadata(new IndexMetadata.ObjectType(ImmutableList.of()));
+                    }
                     mappings = mappings.elements().next();
                 }
 

--- a/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
+++ b/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
@@ -805,4 +805,12 @@ public class TestElasticsearchIntegrationSmokeTest
         client.getLowLevelClient()
                 .performRequest("PUT", "/" + indexName, ImmutableMap.of(), new NStringEntity(mapping, ContentType.APPLICATION_JSON));
     }
+
+    @Test
+    public void testEmptyIndexNoMappings()
+            throws IOException
+    {
+        client.getLowLevelClient().performRequest("PUT", "/emptyindex");
+        assertQueryFails("SELECT * FROM emptyindex", "line 1:8: SELECT \\* not allowed from relation that has no columns");
+    }
 }


### PR DESCRIPTION
## Description
Handled an Exception if table doesn't have columns in elaticsearch by adding an catch block. 

## Motivation and Context
There have an possibility in elasticsearch that we can create index without any columns that is throwing an internal error in presto.

like this 
`PUT /test_empty_profile`

when i run that in presto
<img width="612" alt="image" src="https://github.com/user-attachments/assets/b3b9991a-4ff8-429a-bac4-eb2444ceef59">


After the fix it's got solved
<img width="800" alt="image" src="https://github.com/user-attachments/assets/095510a8-b29d-4497-9039-d4bae2bcaf64">
